### PR TITLE
skip returning initial guess value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,11 +63,9 @@ where
         let deriv = &self.derivative;
 
         let next = self.current - (func(self.current) / deriv(self.current));
-        let prev = self.current;
 
         self.current = next;
-
-        Some(prev)
+        Some(next)
     }
 }
 


### PR DESCRIPTION
In this commit, the iterator implementation is changed to always return
the next value, rather than the previous value. This has the result that
the value returned from the initial call to `.next()` will no longer
return the initial guess but rather the result of the first step using
Newton's method.

The justification for this change is that it is more efficient (one less
function call) and that the results of two successive iterations can be
compared to check for convergence without skipping the first returned
value.